### PR TITLE
remove a line -> fix gmaps rendering on responsive layout resize

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -165,9 +165,6 @@
 						initPersonelListHandlers();
 						initRodoAccordion();
 
-						jQuery('.mh-100').imagefill();
-
-
 						$(function () {
 							Grid.init();
 						});


### PR DESCRIPTION
frankly I have little idea what's going on

i just kept removing lines until the gmaps behaviour fixed itself...

the line I removed has something to do with resizing images (or elements?), but i can't see anything breaking...

@enigosi - maybe you have a better idea!