### PR TITLE
change the order of commands in make update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,5 @@ serve:
 	bundle exec jekyll serve
 
 update:
-	bundle update --ruby
-	bundle update --bundler
 	bundle update --all
+	bundle update --bundler --ruby


### PR DESCRIPTION
it appears that actual dependencies need to be dealt with first, then bundler and ruby