### PR TITLE
do not pin things that cannot / should not be pinned

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem "github-pages", "~> 214", group: :jekyll_plugins
+gem "github-pages", group: :jekyll_plugins
 
 # The old version was chosen for compatibility with latest version of susy.
 # For some reason, the fact that breakpoint depends on `sass ~> 3.3`
@@ -18,7 +18,7 @@ gem "susy", "~> 2.2.14"
 gem "breakpoint", "~> 2.7.1"
 
 group :development do
-  gem 'reek', '~> 6.0.4', require: false
-  gem 'rubocop', '~> 1.14.0', require: false
-  gem 'solargraph', '~> 0.40.4', require: false
+  gem 'reek', require: false
+  gem 'rubocop', require: false
+  gem 'solargraph', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,11 +330,11 @@ PLATFORMS
 DEPENDENCIES
   breakpoint (~> 2.7.1)
   compass (~> 1.0.3)
-  github-pages (~> 214)
-  reek (~> 6.0.4)
-  rubocop (~> 1.14.0)
+  github-pages
+  reek
+  rubocop
   sass (~> 3.4.25)
-  solargraph (~> 0.40.4)
+  solargraph
   susy (~> 2.2.14)
 
 BUNDLED WITH


### PR DESCRIPTION
i think the github-pages environment gets updated by github no matter what i specify in the gemfile

similarly, no reason to not just upgrade the dev dependencies